### PR TITLE
Improve catch error handling

### DIFF
--- a/app/(auth)/ForgotPassword.tsx
+++ b/app/(auth)/ForgotPassword.tsx
@@ -68,7 +68,8 @@ const ForgotPassword: React.FC = () => {
 
         setResetSent(true);
         console.log('Demande de réinitialisation envoyée à:', email);
-      } catch  {
+      } catch (error) {
+        console.error(error);
         Alert.alert(
           'Erreur',
           'Une erreur est survenue lors de l\'envoi de l\'email de réinitialisation. Veuillez réessayer.'
@@ -107,7 +108,8 @@ const ForgotPassword: React.FC = () => {
         'Email envoyé',
         `Un nouvel email de réinitialisation a été envoyé à ${email}.`
       );
-    } catch  {
+    } catch (error) {
+      console.error(error);
       Alert.alert(
         'Erreur',
         'Une erreur est survenue lors de l\'envoi de l\'email de réinitialisation. Veuillez réessayer.'

--- a/app/(auth)/ResetPassword.tsx
+++ b/app/(auth)/ResetPassword.tsx
@@ -84,7 +84,8 @@ const ResetPassword: React.FC = () => {
         }
 
         setResetComplete(true);
-      } catch  {
+      } catch (error) {
+        console.error(error);
         Alert.alert(
           'Erreur',
           'Une erreur est survenue lors de la réinitialisation du mot de passe. Veuillez réessayer.'

--- a/app/(tabs)/AddMedication.tsx
+++ b/app/(tabs)/AddMedication.tsx
@@ -203,7 +203,8 @@ const AddMedication: React.FC = () => {
           }
         }
         */
-      } catch  {
+      } catch (error) {
+        console.error(error);
         Alert.alert('Erreur', 'Une erreur est survenue lors de l\'ajout du médicament');
       } finally {
         setIsSubmitting(false);

--- a/app/(tabs)/MedicationList.tsx
+++ b/app/(tabs)/MedicationList.tsx
@@ -37,7 +37,8 @@ const MedicationList: React.FC = () => {
       } else {
         setError('Impossible de charger la liste des médicaments');
       }
-    } catch  {
+    } catch (error) {
+      console.error(error);
       setError('Une erreur est survenue lors du chargement des données');
     } finally {
       setLoading(false);
@@ -81,7 +82,8 @@ const MedicationList: React.FC = () => {
                 loadMedications(); // Recharger la liste
               }
               */
-            } catch  {
+            } catch (error) {
+              console.error(error);
               Alert.alert(
                 'Erreur',
                 'Impossible de supprimer le médicament. Veuillez réessayer.'

--- a/app/(tabs)/Reminders.tsx
+++ b/app/(tabs)/Reminders.tsx
@@ -46,7 +46,8 @@ const Reminders: React.FC = () => {
       } else {
         setError('Impossible de charger la liste des rappels');
       }
-    } catch  {
+    } catch (error) {
+      console.error(error);
       setError('Une erreur est survenue lors du chargement des données');
     } finally {
       setLoading(false);
@@ -113,7 +114,8 @@ const Reminders: React.FC = () => {
                 ));
               }
               */
-            } catch  {
+            } catch (error) {
+              console.error(error);
               Alert.alert('Erreur', 'Impossible de mettre à jour le statut du rappel');
             }
           },


### PR DESCRIPTION
## Summary
- replace empty `catch` blocks with `catch (error)`
- log the caught error before showing alerts

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b2c19b0248332a22dc8ea43ddba72