### PR TITLE
Fix fontFamily syntax in theme.tsx

### DIFF
--- a/app/styles/theme.tsx
+++ b/app/styles/theme.tsx
@@ -28,8 +28,7 @@ const theme = {
         xxlarge: 22,
         title: 28,
       },
-      fontFamily: Platform.OS === 'web' ? "'Space Mono', 'monospace' : monospace" :
-      undefined, // Utiliser la police par défaut de React Native
+      fontFamily: Platform.OS === 'web' ? "'Space Mono', 'monospace'" : undefined,
     },
     borderRadius: {
       small: 4,


### PR DESCRIPTION
## Summary
- fix fontFamily line in the theme configuration

## Testing
- `npm run lint` *(fails: expo not found)*
- `npx tsc --noEmit` *(fails: compiler errors and missing dependencies)*


------
https://chatgpt.com/codex/tasks/task_e_684b2b3cfac083328107454c006f46b3